### PR TITLE
Enhance CS 252 description with up-to-date RISC-V information 

### DIFF
--- a/content/index.md
+++ b/content/index.md
@@ -28,9 +28,10 @@ About the courses:
   - Math majors usually say it's easy. I found it to be of medium difficulty, and was glad that I had the data-structures background from 300 before I took it.
   - This class is taught by the CS department in the fall, and the Math department in the spring. Both departments claim the offerings are identical, and the curriculums are now more aligned (but students still debate their comparative virtues).
   - ~~The official textbook is a Zybook, but~~ I found [*Discrete Mathematics: An Open Introduction*](http://discrete.openmathbooks.org/dmoi3.html) useful as well. See past teachings for the CS Dept's supplemental readings: [Beck Hasti '21](https://pages.cs.wisc.edu/~cs240-1/).
-- **CS 252** explores how computers work from the transistor up, and teaches a simulated "LC3" assembly language.
+- **CS 252** explores how computers work from the transistor up, and teaches a simulated "LC3" assembly language as well as RISC-V.
   - The textbook used is Patt and Patel's *Introduction to Computing Systems* (9780072467505).
   - Slides from past teachings of this course can be found online. See: [Ibrahim '17](https://pages.cs.wisc.edu/~adilgsm/cs252/Fall2017/)
+  - Some sections now teach in simulated RISC-V instead.
 - **CS 354** (my favorite) is a traditional intro systems course. In this class, you become intimately familiar with memory management and the processor, as well as C programming and reading x86-64 assembly.
   - The textbook is [*Computer Systems: A Programmer's Perspective* (3e)](https://csapp.cs.cmu.edu). [K&R](https://en.wikipedia.org/wiki/The_C_Programming_Language) is also listed as a supplemental text.
   - See these past semesters' materials for an idea of the topics covered: [Gerald '18](https://pages.cs.wisc.edu/~gerald/cs354/Spring18/), [Doescher '21](https://www.youtube.com/channel/UCnZQK7axg01G1b1v4xEQp9A)
@@ -54,7 +55,7 @@ See [the actual UW page](https://spanport.wisc.edu/placement-and-retros/) for up
 ---
 
 ### Running a DARS audit
-
+LEC: Enrollment in ECE 252 will be limited to Engineering students only until August 17 by noon. If you are interested in applying to the EE or CMPE programs, once you are admitted into the program, you will receive priority consideration for enrollment in ECE 252. 
 A DARS audit will tell you what you have completed and what you still need to graduate. To run a DARS audit, go to Course Search & Enroll at https://enroll.wisc.edu, and select "Degree Audit (DARS)" at the top of the page. Then follow these steps to see what you would need for a given degree plan:
 
 ![DARS audit](dars-audit.jpg)

--- a/content/index.md
+++ b/content/index.md
@@ -31,7 +31,7 @@ About the courses:
 - **CS 252** explores how computers work from the transistor up, and teaches a simulated "LC3" assembly language as well as RISC-V.
   - The textbook used is Patt and Patel's *Introduction to Computing Systems* (9780072467505).
   - Slides from past teachings of this course can be found online. See: [Ibrahim '17](https://pages.cs.wisc.edu/~adilgsm/cs252/Fall2017/)
-  - Some sections now teach in simulated RISC-V instead.
+  - Some sections now teach in simulated RISC-V instead of LC3.
 - **CS 354** (my favorite) is a traditional intro systems course. In this class, you become intimately familiar with memory management and the processor, as well as C programming and reading x86-64 assembly.
   - The textbook is [*Computer Systems: A Programmer's Perspective* (3e)](https://csapp.cs.cmu.edu). [K&R](https://en.wikipedia.org/wiki/The_C_Programming_Language) is also listed as a supplemental text.
   - See these past semesters' materials for an idea of the topics covered: [Gerald '18](https://pages.cs.wisc.edu/~gerald/cs354/Spring18/), [Doescher '21](https://www.youtube.com/channel/UCnZQK7axg01G1b1v4xEQp9A)

--- a/content/index.md
+++ b/content/index.md
@@ -68,4 +68,4 @@ During the semester, drop by the [Undergraduate Projects Lab (UPL)](https://www.
 
 ---
 
-<small>Created by [Michael Noguera](https://noguera.dev) as an unofficial resource for those going to SOAR. Created June 2022. Last updated September 2024.</small>
+<small>Created by [Michael Noguera](https://noguera.dev) as an unofficial resource for those going to SOAR. Created June 2022. Last updated May 2026.</small>

--- a/content/index.md
+++ b/content/index.md
@@ -55,7 +55,6 @@ See [the actual UW page](https://spanport.wisc.edu/placement-and-retros/) for up
 ---
 
 ### Running a DARS audit
-LEC: Enrollment in ECE 252 will be limited to Engineering students only until August 17 by noon. If you are interested in applying to the EE or CMPE programs, once you are admitted into the program, you will receive priority consideration for enrollment in ECE 252. 
 A DARS audit will tell you what you have completed and what you still need to graduate. To run a DARS audit, go to Course Search & Enroll at https://enroll.wisc.edu, and select "Degree Audit (DARS)" at the top of the page. Then follow these steps to see what you would need for a given degree plan:
 
 ![DARS audit](dars-audit.jpg)

--- a/content/index.md
+++ b/content/index.md
@@ -55,6 +55,7 @@ See [the actual UW page](https://spanport.wisc.edu/placement-and-retros/) for up
 ---
 
 ### Running a DARS audit
+
 A DARS audit will tell you what you have completed and what you still need to graduate. To run a DARS audit, go to Course Search & Enroll at https://enroll.wisc.edu, and select "Degree Audit (DARS)" at the top of the page. Then follow these steps to see what you would need for a given degree plan:
 
 ![DARS audit](dars-audit.jpg)


### PR DESCRIPTION
As of 2026, CS252 now teaches in RISC-V. They started doing so probably around 2025, though I don't know the exact date. Whether they still instruct LC3 in other sections I do not know, would need more information. 